### PR TITLE
Keep json data

### DIFF
--- a/src/libs/CSharpGenerator/BaseTypes.fs
+++ b/src/libs/CSharpGenerator/BaseTypes.fs
@@ -1,5 +1,8 @@
 namespace CSharpGenerator.Types
 
+open System
+open System
+open System.Collections.Generic
 open Common.Casing
 open Common.StringUtils
 
@@ -114,7 +117,7 @@ type internal TypeInfo =
       Namespace: string
       Alias: string option
       Nullable: bool }
-    override this.ToString() = this.Alias |> Option.defaultValue ([ this.Namespace; "."; this.Name ] |> joinStrings)
+    member this.ToString() = this.Alias |> Option.defaultValue ([ this.Namespace; "."; this.Name ] |> joinStrings)
     member this.AsNullable =
         if this.Nullable then
             this
@@ -126,53 +129,82 @@ type internal TypeInfo =
               Alias = this.Alias |> Option.map nullableConcat
               Nullable = true }
 
-type internal BaseType =
+type internal ValueTypePair<'T> =
+    { Value: 'T
+      Type: TypeInfo }
+
+and internal ValueType =
+    | Integer of ValueTypePair<int>
+    | Guid of ValueTypePair<Guid>
+    | Boolean of ValueTypePair<bool>
+    | Datetime of ValueTypePair<DateTime>
+    | Decimal of ValueTypePair<decimal>
+    | Double of ValueTypePair<double>
+
+and internal BaseType =
     | ReferenceType of TypeInfo
-    | ValueType of TypeInfo
+    | ValueType of ValueType
 
     member private this.TypeInfo =
         match this with
         | ReferenceType x -> x
-        | ValueType x -> x
+        | ValueType x ->
+            match x with
+            | Integer x -> x.Type
+            | Guid x -> x.Type
+            | Boolean x -> x.Type
+            | Datetime x -> x.Type
+            | Decimal x -> x.Type
+            | Double x -> x.Type
 
     member this.FormatArray key = this.TypeInfo |> fun x -> Formatters.arrayProperty (x.ToString()) key
 
     member this.FormatProperty key = this.TypeInfo |> fun x -> Formatters.property (x.ToString()) key
 
-    static member Guid =
-        { Namespace = "System"
-          Name = "Guid"
-          Alias = option.None
-          Nullable = false }
-        |> ValueType
+    static member Guid x =
+        { Type =
+              { Namespace = "System"
+                Name = "Guid"
+                Alias = option.None
+                Nullable = false }
+          Value = x }
+        |> ValueType.Guid
 
-    static member Double =
-        { Namespace = "System"
-          Name = "Double"
-          Alias = option.Some "double"
-          Nullable = false }
-        |> ValueType
+    static member Double x =
+        { Type =
+              { Namespace = "System"
+                Name = "Double"
+                Alias = option.Some "double"
+                Nullable = false }
+          Value = x }
+        |> ValueType.Double
 
-    static member Boolean =
-        { Namespace = "System"
-          Name = "Boolean"
-          Alias = option.Some "bool"
-          Nullable = false }
-        |> ValueType
+    static member Boolean x =
+        { Type =
+              { Namespace = "System"
+                Name = "Boolean"
+                Alias = option.Some "bool"
+                Nullable = false }
+          Value = x }
+        |> ValueType.Boolean
 
-    static member DateTime =
-        { Namespace = "System"
-          Name = "DateTime"
-          Alias = option.None
-          Nullable = false }
-        |> ValueType
+    static member DateTime x =
+        { Type =
+              { Namespace = "System"
+                Name = "DateTime"
+                Alias = option.None
+                Nullable = false }
+          Value = x }
+        |> ValueType.Datetime
 
-    static member Decimal =
-        { Namespace = "System"
-          Name = "Decimal"
-          Alias = Option.Some "decimal"
-          Nullable = false }
-        |> ValueType
+    static member Decimal x =
+        { Type =
+              { Namespace = "System"
+                Name = "Decimal"
+                Alias = option.Some "decimal"
+                Nullable = false }
+          Value = x }
+        |> ValueType.Decimal
 
     static member Object =
         { Name = "Object"

--- a/src/libs/CSharpGenerator/BaseTypes.fs
+++ b/src/libs/CSharpGenerator/BaseTypes.fs
@@ -2,6 +2,8 @@ namespace CSharpGenerator.Types
 
 open System
 open System
+open System
+open System
 open System.Collections.Generic
 open Common.Casing
 open Common.StringUtils
@@ -117,7 +119,7 @@ type internal TypeInfo =
       Namespace: string
       Alias: string option
       Nullable: bool }
-    member this.ToString() = this.Alias |> Option.defaultValue ([ this.Namespace; "."; this.Name ] |> joinStrings)
+    override this.ToString() = this.Alias |> Option.defaultValue ([ this.Namespace; "."; this.Name ] |> joinStrings)
     member this.AsNullable =
         if this.Nullable then
             this
@@ -132,6 +134,9 @@ type internal TypeInfo =
 type internal ValueTypePair<'T> =
     { Value: 'T
       Type: TypeInfo }
+    member pair.AsNullable =
+        { Value = pair.Value
+          Type = pair.Type.AsNullable }
 
 and internal ValueType =
     | Integer of ValueTypePair<int>
@@ -140,6 +145,15 @@ and internal ValueType =
     | Datetime of ValueTypePair<DateTime>
     | Decimal of ValueTypePair<decimal>
     | Double of ValueTypePair<double>
+    member valueType.AsNullable =
+        match valueType with
+        | Integer x -> x.AsNullable |> ValueType.Integer
+        | Guid x -> x.AsNullable |> ValueType.Guid
+        | Boolean x -> x.AsNullable |> ValueType.Boolean
+        | Datetime x -> x.AsNullable |> ValueType.Datetime
+        | Decimal x -> x.AsNullable |> ValueType.Decimal
+        | Double x -> x.AsNullable |> ValueType.Double
+
 
 and internal BaseType =
     | ReferenceType of TypeInfo

--- a/src/libs/CSharpGenerator/BaseTypes.fs
+++ b/src/libs/CSharpGenerator/BaseTypes.fs
@@ -253,6 +253,7 @@ type internal GeneratedType =
       NamePrefix: string
       NameSuffix: string
       Casing: Casing }
+    
     member this.FormatProperty ``type`` name = Formatters.property ``type`` name
     member this.ClassDeclaration name =
         let name = [ this.NamePrefix; name; this.NameSuffix ] |> joinStrings

--- a/src/libs/CSharpGenerator/BaseTypes.fs
+++ b/src/libs/CSharpGenerator/BaseTypes.fs
@@ -150,30 +150,31 @@ and internal ValueType =
         | Datetime x -> x.AsNullable |> ValueType.Datetime
         | Decimal x -> x.AsNullable |> ValueType.Decimal
         | Double x -> x.AsNullable |> ValueType.Double
+    member this.TypeInfo =
+        match this with
+        | Integer x -> x.Type
+        | Guid x -> x.Type
+        | Boolean x -> x.Type
+        | Datetime x -> x.Type
+        | Decimal x -> x.Type
+        | Double x -> x.Type
+        
 
 and internal ReferenceType =
     | String of ValueTypePair<string>
     | Object of TypeInfo
+    member this.TypeInfo =
+        match this with
+        | String x -> x.Type
+        | Object x -> x
 
 and internal BaseType =
     | ReferenceType of ReferenceType
     | ValueType of ValueType
-    member this.TypeEquals (x: BaseType) =
-        this.TypeInfo = x.TypeInfo
-    member private this.TypeInfo =
+    member this.TypeInfo =
         match this with
-        | ReferenceType x ->
-            match x with
-            | String x -> x.Type
-            | Object x -> x
-        | ValueType x ->
-            match x with
-            | Integer x -> x.Type
-            | Guid x -> x.Type
-            | Boolean x -> x.Type
-            | Datetime x -> x.Type
-            | Decimal x -> x.Type
-            | Double x -> x.Type
+        | ReferenceType x -> x.TypeInfo
+        | ValueType x -> x.TypeInfo
 
     member this.FormatArray key = this.TypeInfo |> fun x -> Formatters.arrayProperty (x.ToString()) key
 

--- a/src/libs/CSharpGenerator/CSharp.fs
+++ b/src/libs/CSharpGenerator/CSharp.fs
@@ -62,12 +62,9 @@ type CSharp =
             match previous, current with
             | BaseType previous, BaseType current ->
                 match previous, current with
+                | previous, current when previous.TypeInfo = current.TypeInfo -> current |> CSType.BaseType
                 | BaseType.ValueType previous, BaseType.ValueType current ->
                     match previous, current with
-                    | previous, current when previous.TypeInfo = current.TypeInfo ->
-                        current
-                        |> BaseType.ValueType
-                        |> CSType.BaseType
                     | previous, current when current.TypeInfo = previous.TypeInfo.AsNullable ->
                         current
                         |> BaseType.ValueType
@@ -77,10 +74,6 @@ type CSharp =
                         |> BaseType.ValueType
                         |> CSType.BaseType
                     | _ -> CSType.UnresolvedBaseType
-                | ReferenceType previous, ReferenceType current when previous.TypeInfo = current.TypeInfo ->
-                    previous
-                    |> BaseType.ReferenceType
-                    |> CSType.BaseType
                 | _ -> CSType.UnresolvedBaseType
             | ArrayType previous, ArrayType current -> createBaseType previous current parent |> CSType.ArrayType
             | GeneratedType previous, GeneratedType current ->

--- a/src/libs/CSharpGenerator/CSharp.fs
+++ b/src/libs/CSharpGenerator/CSharp.fs
@@ -114,34 +114,29 @@ type CSharp =
             function
             | DateTime x ->
                 BaseType.DateTime x
-                |> BaseType.ValueType
                 |> CSType.BaseType
                 |> Option.Some
             | JsonParser.Decimal x ->
                 BaseType.Decimal x
-                |> BaseType.ValueType
                 |> CSType.BaseType
                 |> Option.Some
-            | String _ ->
-                BaseType.String
+            | JsonParser.String x ->
+                BaseType.String x
                 |> CSType.BaseType
                 |> Option.Some
             | JsonParser.Boolean x ->
                 BaseType.Boolean  x
-                |> BaseType.ValueType
                 |> CSType.BaseType
                 |> Option.Some
             | JsonParser.Guid x ->
                 BaseType.Guid x
-                |> BaseType.ValueType
                 |> CSType.BaseType
                 |> Option.Some
             | JsonParser.Double x ->
                 BaseType.Double x
-                |> BaseType.ValueType
                 |> CSType.BaseType
                 |> Option.Some
-            | Object x ->
+            | JsonParser.Object x ->
                 x
                 |> generatedType
                 |> Option.Some
@@ -159,10 +154,9 @@ type CSharp =
                     values
                     |> Array.map baseType
 
+                // TODO create a equals which only checks types and do not care about values.
                 baseTypes
                 |> Array.reduce (fun previous current ->
-                    // Since values are now kept, previous will not be equal to current unless the value behind the type is the same
-                    // We might as well start tracking the value from the reference types as well.
                     match previous, current with
                     | previous, current when previous = current -> current
                     | (Some previous, Some current) ->

--- a/src/libs/CSharpGenerator/CSharp.fs
+++ b/src/libs/CSharpGenerator/CSharp.fs
@@ -76,6 +76,10 @@ type CSharp =
                         |> BaseType.ValueType
                         |> CSType.BaseType
                     | _ -> CSType.UnresolvedBaseType
+                | ReferenceType previous, ReferenceType current when previous.TypeInfo = current.TypeInfo ->
+                    previous
+                    |> BaseType.ReferenceType
+                    |> CSType.BaseType
                 | _ -> CSType.UnresolvedBaseType
             | ArrayType previous, ArrayType current -> createBaseType previous current |> CSType.ArrayType
             | _ -> CSType.UnresolvedBaseType
@@ -125,7 +129,7 @@ type CSharp =
                 |> CSType.BaseType
                 |> Option.Some
             | JsonParser.Boolean x ->
-                BaseType.Boolean  x
+                BaseType.Boolean x
                 |> CSType.BaseType
                 |> Option.Some
             | JsonParser.Guid x ->
@@ -151,8 +155,7 @@ type CSharp =
             | values when values.Length = 0 -> CSType.UnresolvedBaseType
             | values ->
                 let baseTypes =
-                    values
-                    |> Array.map baseType
+                    values |> Array.map baseType
 
                 // TODO create a equals which only checks types and do not care about values.
                 baseTypes

--- a/src/libs/CSharpGenerator/CSharp.fs
+++ b/src/libs/CSharpGenerator/CSharp.fs
@@ -117,6 +117,8 @@ type CSharp =
                 |> CSType.BaseType
                 |> Option.Some
             | Decimal _ ->
+                // IN order to achieve number prediction, decimal would need to be a part of Discriminated Unions
+                // Instead of a plain data object. Making all CsTypes generic could solve it as well but it would be a lot more complex.
                 BaseType.Decimal
                 |> CSType.BaseType
                 |> Option.Some

--- a/src/libs/CSharpGenerator/CSharp.fs
+++ b/src/libs/CSharpGenerator/CSharp.fs
@@ -112,30 +112,33 @@ type CSharp =
 
         let rec baseType =
             function
-            | DateTime _ ->
-                BaseType.DateTime
+            | DateTime x ->
+                BaseType.DateTime x
+                |> BaseType.ValueType
                 |> CSType.BaseType
                 |> Option.Some
-            | Decimal _ ->
-                // IN order to achieve number prediction, decimal would need to be a part of Discriminated Unions
-                // Instead of a plain data object. Making all CsTypes generic could solve it as well but it would be a lot more complex.
-                BaseType.Decimal
+            | JsonParser.Decimal x ->
+                BaseType.Decimal x
+                |> BaseType.ValueType
                 |> CSType.BaseType
                 |> Option.Some
             | String _ ->
                 BaseType.String
                 |> CSType.BaseType
                 |> Option.Some
-            | Boolean _ ->
-                BaseType.Boolean
+            | JsonParser.Boolean x ->
+                BaseType.Boolean  x
+                |> BaseType.ValueType
                 |> CSType.BaseType
                 |> Option.Some
-            | Guid _ ->
-                BaseType.Guid
+            | JsonParser.Guid x ->
+                BaseType.Guid x
+                |> BaseType.ValueType
                 |> CSType.BaseType
                 |> Option.Some
-            | Double _ ->
-                BaseType.Double
+            | JsonParser.Double x ->
+                BaseType.Double x
+                |> BaseType.ValueType
                 |> CSType.BaseType
                 |> Option.Some
             | Object x ->

--- a/src/libs/CSharpGenerator/CSharp.fs
+++ b/src/libs/CSharpGenerator/CSharp.fs
@@ -82,6 +82,7 @@ type CSharp =
                     |> CSType.BaseType
                 | _ -> CSType.UnresolvedBaseType
             | ArrayType previous, ArrayType current -> createBaseType previous current |> CSType.ArrayType
+            | GeneratedType previous, GeneratedType current -> CSType.UnresolvedBaseType //TODO resolve previous and current
             | _ -> CSType.UnresolvedBaseType
 
         let createProperty previous current =

--- a/src/libs/CSharpGenerator/CSharp.fs
+++ b/src/libs/CSharpGenerator/CSharp.fs
@@ -63,15 +63,15 @@ type CSharp =
                 match previous, current with
                 | BaseType.ValueType previous, BaseType.ValueType current ->
                     match previous, current with
-                    | previous, current when previous = current ->
+                    | previous, current when previous.TypeInfo = current.TypeInfo ->
                         current
                         |> BaseType.ValueType
                         |> CSType.BaseType
-                    | previous, current when current = previous.AsNullable ->
+                    | previous, current when current.TypeInfo = previous.TypeInfo.AsNullable ->
                         current
                         |> BaseType.ValueType
                         |> CSType.BaseType
-                    | previous, current when previous = current.AsNullable ->
+                    | previous, current when previous.TypeInfo = current.TypeInfo.AsNullable ->
                         previous
                         |> BaseType.ValueType
                         |> CSType.BaseType

--- a/src/libs/CSharpGenerator/CSharp.fs
+++ b/src/libs/CSharpGenerator/CSharp.fs
@@ -108,9 +108,8 @@ type CSharp =
             | previous, current when current.Type.IsNone || current.Type.Value = CSType.UnresolvedBaseType ->
                 tryConvertToNullableValueTypeProperty previous
             | previous, current ->
-                let baseTypeMapper x y = createBaseType x y parent
                 { Name = previous.Name
-                  Type = Option.map2 baseTypeMapper previous.Type current.Type }
+                  Type = Option.map2 (fun x y -> createBaseType x y parent) previous.Type current.Type }
 
         let rec baseType =
             function
@@ -140,7 +139,7 @@ type CSharp =
                 |> Option.Some
             | JsonParser.Object records ->
                 match records with
-                | records when records.Length = 0 -> CSType.UnresolvedBaseType 
+                | records when records.Length = 0 -> CSType.UnresolvedBaseType
                 | records ->
                     records
                     |> Array.map (fun x ->

--- a/src/libs/CSharpGenerator/CSharp.fs
+++ b/src/libs/CSharpGenerator/CSharp.fs
@@ -161,6 +161,8 @@ type CSharp =
 
                 baseTypes
                 |> Array.reduce (fun previous current ->
+                    // Since values are now kept, previous will not be equal to current unless the value behind the type is the same
+                    // We might as well start tracking the value from the reference types as well.
                     match previous, current with
                     | previous, current when previous = current -> current
                     | (Some previous, Some current) ->

--- a/test/CSharpGeneratorTests/CSharpFileTests.fs
+++ b/test/CSharpGeneratorTests/CSharpFileTests.fs
@@ -277,6 +277,37 @@ let ``Two array Objects next to each other``() =
     let expected =
         "public class RootModel { public string[] Tags { get; set; } public class FriendsModel { public decimal Id { get; set; } public string Name { get; set; } } public FriendsModel[] Friends { get; set; } } public RootModel[] Root { get; set; }"
     arrayEntryAssertion expected result.Either.Value
+    
+[<Fact>]
+let ``Two array Objects next to each other with different properties should expand properties``() =
+    let json = """
+    [
+      {
+        "tags": [ "non" ],
+        "friends": [
+          {
+            "id": 0,
+            "name": "Henrietta Tillman"
+          }
+        ],
+        "john" : ""
+      },
+      {
+    "tags": [ "aliqua" ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Kristy Calhoun"
+      }
+    ],
+    "doe" : ""
+  }
+    ]
+    """
+    let result = CSharp.CreateFile json
+    let expected =
+        "public class RootModel { public string[] Tags { get; set; } public class FriendsModel { public decimal Id { get; set; } public string Name { get; set; } } public FriendsModel[] Friends { get; set; } public string John { get; set; } public string Doe { get; set; } } public RootModel[] Root { get; set; }"
+    arrayEntryAssertion expected result.Either.Value
 
 [<Fact>]
 let ``Camel case Object``() =


### PR DESCRIPTION
Refactors the code to keep the JSON values.

This will enable functionality such as determining if the provided numbers what kind of numbers are provided. 