### PR TITLE
Avoid class name collisions

### DIFF
--- a/src/libs/CSharpGenerator/BaseTypes.fs
+++ b/src/libs/CSharpGenerator/BaseTypes.fs
@@ -256,11 +256,14 @@ type internal GeneratedType =
     
     member this.FormatProperty ``type`` name = Formatters.property ``type`` name
     member this.ClassDeclaration name =
+        let set = Set.empty.Add name
         let name = [ this.NamePrefix; name; this.NameSuffix ] |> joinStrings
         this.Members
         |> Seq.map (fun property ->
             match property.Type |> Option.defaultValue CSType.UnresolvedBaseType with
             | GeneratedType x ->
+                if set.Contains property.Name then raise(System.ArgumentException("Member names cannot be the same as their enclosing type"))
+                else 
                 [ x.ClassDeclaration property.Name
                   x.FormatProperty ([ x.NamePrefix; property.Name; x.NameSuffix ] |> joinStrings) property.Name ]
                 |> joinStringsWithSpaceSeparation

--- a/test/CSharpGeneratorTests/CSharpFileTests.fs
+++ b/test/CSharpGeneratorTests/CSharpFileTests.fs
@@ -4,6 +4,7 @@ open CSharpGenerator
 open CSharpGenerator.Arguments
 open Common.Casing
 open Xunit
+open Xunit
 
     
 [<Fact>]
@@ -732,6 +733,13 @@ let ``Array with objects with different amount of properties``() =
         "public class RootModel { public string Foo { get; set; } public decimal Bar { get; set; } public decimal? Test { get; set; } }"
     Assert.Equal(expected, result.Either.Value)
     
+[<Theory>]
+[<InlineData("""{"Root": {"foo":2}}""")>]
+[<InlineData("""{"Nested": {"Root": {"foo":2}}}""")>]
+let ``Member names is the same as their enclosing typex`` json =
+    let result = CSharp.CreateFile json
+    let expected = "Member names cannot be the same as their enclosing type"
+    Assert.Equal(expected, result.Either.Error.Message)
     
 [<Fact>]
 let ``Array with object does not leave trailing array``() =

--- a/test/CSharpGeneratorTests/CSharpFileTests.fs
+++ b/test/CSharpGeneratorTests/CSharpFileTests.fs
@@ -734,9 +734,10 @@ let ``Array with objects with different amount of properties``() =
     Assert.Equal(expected, result.Either.Value)
     
 [<Theory>]
-[<InlineData("""{"Root": {"foo":2}}""")>]
 [<InlineData("""{"Nested": {"Root": {"foo":2}}}""")>]
-let ``Member names is the same as their enclosing typex`` json =
+[<InlineData("""{"Nested": {"Root": []}}""")>]
+[<InlineData("""{"Nested": {"Root": 1}}""")>]
+let ``Member names is the same as their enclosing type`` json =
     let result = CSharp.CreateFile json
     let expected = "Member names cannot be the same as their enclosing type"
     Assert.Equal(expected, result.Either.Error.Message)


### PR DESCRIPTION
Will raise an exception when member names collide with outer type names. 